### PR TITLE
[WFLY-18382] Update WFLY and EJB Maven plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <product.name>WildFly</product.name>
         <!-- A base list of dependency and plug-in version used in the various quick starts. -->
         <version.org.asciidoctor.asciidoctor-maven-plugin>2.1.0</version.org.asciidoctor.asciidoctor-maven-plugin>
-        <version.wildfly.maven.plugin>4.0.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>4.2.0.Final</version.wildfly.maven.plugin>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
         <!-- other plug-in versions -->
         <version.com.mycyla.license>3.0</version.com.mycyla.license>
@@ -179,7 +179,7 @@
                     <version>${version.ejb.plugin}</version>
                     <configuration>
                         <!-- Tell Maven we are using EJB -->
-                        <ejbVersion>3.2</ejbVersion>
+                        <ejbVersion>3.2.1</ejbVersion>
                     </configuration>
                 </plugin>
                 <!-- Checkstyle -->


### PR DESCRIPTION
The issue: [WFLY-18382](https://issues.redhat.com/browse/WFLY-18382)

Though each QS defines own WFLY Maven plugin version in its pom.xml, it's better to have a single version among all QS (and parent as well).

If I'm not mistaken, the EJB Maven plugin should have version [3.2.1](https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-ejb-plugin) instead of 3.2, but feel free to correct me.