### PR TITLE
[WFLY-18769] Expose the artifact version as an asciidoc attribute so …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
                             <backend>html5</backend>
                             <attributes>
                                 <artifactId>${project.artifactId}</artifactId>
+                                <artifactVersion>${project.version}</artifactVersion>
                             </attributes>
                             <resources>
                                 <resource>


### PR DESCRIPTION
…we can use it in 'Browse the source' links that target tags on GitHub

This is a subtask of https://issues.redhat.com/browse/WFLY-18769