### PR TITLE
[WFLY-21327] Upgrade jboss-parent from 43 to 51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>43</version>
+        <version>51</version>
     </parent>
 
     <groupId>org.wildfly.quickstarts</groupId>


### PR DESCRIPTION
## Summary

- Upgrade `jboss-parent` from version 43 to 51
- Fixes sonar-maven-plugin relocation warning causing CI test failures

## Problem

During CI Maven builds, the following warning is logged:
```
[WARNING] The artifact org.codehaus.mojo:sonar-maven-plugin:jar:3.7.0.1746 has been relocated to org.sonarsource.scanner.maven:sonar-maven-plugin:jar:3.7.0.1746: SonarQube plugin was moved to SonarSource organisation
```

This warning causes test failures in quickstarts CI when log validation checks for unexpected warnings.

**Affected quickstarts:**
- ejb-throws-exception
- ha-singleton-deployment
- http-custom-mechanism
- jta-crash-rec
- security-domain-to-domain

## Solution

The fix for the deprecated `org.codehaus.mojo:sonar-maven-plugin` groupId was introduced in `jboss-parent:46`. This PR upgrades to version 51 to align with WildFly core which already uses `jboss-parent:51` (WFLY-21123).

## References

- JIRA: https://issues.redhat.com/browse/WFLY-21327
- jboss-parent 46 release notes: https://github.com/jboss/jboss-parent-pom/releases/tag/jboss-parent-46